### PR TITLE
Update App test for private mode message

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,45 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import store from './redux/store';
+
+jest.mock('mui-react-hook-form-plus', () => ({
+  HookTextField: () => null,
+  HookSelect: () => null,
+  HookDatePicker: () => null,
+  HookDateTimePicker: () => null,
+  HookTimePicker: () => null,
+  useHookForm: jest.fn(),
+}), { virtual: true });
+
+jest.mock('./components/forms/FormContainer', () => ({
+  WrappedRegistrationForm: () => <div />,
+  WrappedResyTokenForm: () => <div />,
+  WrappedResyResRequestForm: () => <div />,
+  WrappedPasswordResetForm: () => <div />,
+  WrappedRegisterVenueForm: () => <div />,
+  WrappedSignInForm: () => <div />,
+  WrappedBugReportForm: () => <div />,
+}));
+
+jest.mock('./components/user/Profile', () => () => <div />);
+jest.mock('./components/ErrorPage', () => () => <div />);
+jest.mock('./components/user/CheckResyToken', () => () => <div />);
+jest.mock('./components/Navbar', () => () => <div />);
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('./firebase', () => ({
+  auth: { onAuthStateChanged: (cb) => { cb(null); return () => {}; } },
+  getResyToken: jest.fn(),
+}));
+
+test('renders private mode message on home page', () => {
+  render(
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+  expect(
+    screen.getByText(/Currently in private mode, please login or register for access/i)
+  ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- remove default CRA test
- add test for rendering App
- mock components and firebase to isolate Home page
- assert that private mode message displays

## Testing
- `npm --prefix frontend test -- --watchAll=false`