### PR TITLE
Improve setup docs and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# Backend configuration
+# ACTIVE_ENV selects the Flask config class (DevelopmentConfig, ProductionConfig, etc.)
+ACTIVE_ENV=DevelopmentConfig
+# Base URL for the Resy API
+RESY_URL=
+# Name of the CSRF cookie to use
+SECURITY_CSRF_COOKIE_NAME=
+# Resy API key
+RESY_API_KEY=
+# Google Cloud Tasks location
+LOCATION=
+# Cloud Tasks queue name
+QUEUE=
+# GitHub token for issue creation
+GITHUB_TOKEN=
+# Repository in the form owner/repo
+GITHUB_REPO=
+# Email used when sending notifications
+RESY_BOT_EMAIL=
+# Public domain where the bot is hosted
+RESY_BOT_DOMAIN=
+
+# Frontend configuration
+# Google Maps API key
+REACT_APP_MAPS_API_KEY=
+# Firebase configuration values
+REACT_APP_FIREBASE_API_KEY=
+REACT_APP_FIREBASE_AUTH_DOMAIN=
+REACT_APP_FIREBASE_PROJECT_ID=
+REACT_APP_FIREBASE_STORAGE_BUCKET=
+REACT_APP_FIREBASE_MSG_SNDR_ID=
+REACT_APP_FIREBASE_APP_ID=
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,61 @@
 # resy-book-bot
-Customizable booking bot for Resy based on submitted time intervals
 
-A bot designed to create reservations based on given time intervals on [Resy](https://resy.com/) using the
-[ResyAPI](http://subzerocbd.info/). Given a selected restaurant and time, when reservations become available
-the bot will search and attempt to book.
+Customizable booking bot for Resy based on submitted time intervals.
 
-Flask Backend, React Frontend
+A bot designed to create reservations based on given time intervals on [Resy](https://resy.com/) using the [ResyAPI](http://subzerocbd.info/). Given a selected restaurant and time, when reservations become available the bot will search and attempt to book.
+
+Flask Backend, React Frontend.
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 16+
+
+## Setup
+
+### 1. Environment variables
+
+Copy `.env.example` to `.env` and provide values for all fields.
+
+### 2. Backend
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+Run the development server:
+
+```bash
+export FLASK_APP=app/wsgi.py
+python backend/app/wsgi.py
+```
+
+### 3. Frontend
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+`npm start` runs the React development server. To create a production build and move it into the backend run:
+
+```bash
+npm run build
+```
+
+The build output is copied to `backend/app/build` so Flask can serve the files.
+
+### Full Build and Serve
+
+1. Configure `.env`.
+2. Run `npm run build` inside `frontend`.
+3. Start Flask with `python backend/app/wsgi.py`.
+
+The application will be available at `http://localhost:8000` and served entirely from Flask.
+
+## Environment Variables
+
+See `.env.example` for the full list of required variables and their purpose.


### PR DESCRIPTION
## Summary
- add environment variable template and document required values
- rewrite README with prerequisites and setup instructions

## Testing
- `pytest -q` *(fails: command not found)*
- `cd frontend && npm test --silent --watchAll=false`