### PR TITLE
Add pytest tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test -- --watchAll=false

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = backend

--- a/tests/test_resy_client.py
+++ b/tests/test_resy_client.py
@@ -1,0 +1,32 @@
+import pytest
+from sortedcontainers import SortedList
+from app.core.resy_client import build_priority_list
+
+
+def test_build_priority_list_selects_preceding_slots():
+    slots = SortedList(
+        [
+            ("2023-03-04 18:00", "t1"),
+            ("2023-03-04 18:30", "t2"),
+            ("2023-03-04 19:00", "t3"),
+        ],
+        key=lambda s: s[0],
+    )
+
+    res_times = ["2023-03-04 18:15", "2023-03-04 19:15"]
+    result = build_priority_list(slots, res_times)
+    assert result == [("2023-03-04 18:00", "t1"), ("2023-03-04 19:00", "t3")]
+
+
+def test_build_priority_list_exact_match():
+    slots = SortedList(
+        [
+            ("2023-03-04 18:00", "t1"),
+            ("2023-03-04 18:30", "t2"),
+        ],
+        key=lambda s: s[0],
+    )
+
+    res_times = ["2023-03-04 18:30"]
+    result = build_priority_list(slots, res_times)
+    assert result == [("2023-03-04 18:30", "t2")]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,108 @@
+import sys
+import types
+import importlib
+from flask import Flask, Response
+import pytest
+
+
+# helper fixture to create fake 'app' package with required attributes
+@pytest.fixture
+def fake_app(monkeypatch):
+    fake_app = types.ModuleType("app")
+    fake_app.__path__ = []
+    fake_app.logger = None
+    fake_app.bot_domain = "example.com"
+    fake_app.account_handler = types.SimpleNamespace(
+        get_resy_token=lambda uid: "token", remove_resy_token=lambda uid: None
+    )
+    fake_app.task_handler = types.SimpleNamespace()
+    fake_app.resy_client = types.SimpleNamespace(
+        auth_check=lambda payload: Response(status=200)
+    )
+
+    forms_pkg = types.ModuleType("app.forms")
+    forms_pkg.__path__ = []
+    rf = types.ModuleType("app.forms.resy_form")
+
+    class ResyTokenForm:
+        pass
+
+    rf.ResyTokenForm = ResyTokenForm
+    uf = types.ModuleType("app.forms.user_account_forms")
+
+    class RegistrationForm:
+        pass
+
+    uf.RegistrationForm = RegistrationForm
+    forms_pkg.resy_form = rf
+    forms_pkg.user_account_forms = uf
+
+    routes_pkg = types.ModuleType("app.routes")
+    routes_pkg.__path__ = ["backend/app/routes"]
+
+    modules = {
+        "app": fake_app,
+        "app.forms": forms_pkg,
+        "app.forms.resy_form": rf,
+        "app.forms.user_account_forms": uf,
+        "app.routes": routes_pkg,
+    }
+    for name, mod in modules.items():
+        sys.modules[name] = mod
+
+    yield fake_app
+
+    for name in modules.keys():
+        sys.modules.pop(name, None)
+
+
+def create_app(module_path):
+    mod = importlib.import_module(module_path)
+    name = module_path.split(".")[-1]
+    blueprint = getattr(mod, f"{name}_bp", None)
+    if blueprint is None:
+        for candidate in [
+            "resy_bp",
+            "user_bp",
+            "resy_bot_bp",
+            "base_bp",
+            "meta_bp",
+        ]:
+            if hasattr(mod, candidate):
+                blueprint = getattr(mod, candidate)
+                break
+    if blueprint is None:
+        raise AttributeError(f"No blueprint found in {module_path}")
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    return app
+
+
+def test_search_requires_auth(fake_app):
+    app = create_app("app.routes.resy_interactions")
+    client = app.test_client()
+    resp = client.post("/resy/search")
+    assert resp.status_code == 403
+
+
+def test_check_token_success(fake_app):
+    fake_app.resy_client.auth_check = lambda payload: Response(status=200)
+    app = create_app("app.routes.user")
+    client = app.test_client()
+    resp = client.get("/user/check-token", query_string={"userId": "1"})
+    assert resp.status_code == 200
+
+
+def test_check_token_failure(fake_app):
+    removed = {}
+
+    def remove(uid):
+        removed["uid"] = uid
+
+    fake_app.account_handler.remove_resy_token = remove
+    fake_app.resy_client.auth_check = lambda payload: Response(status=500)
+    app = create_app("app.routes.user")
+    client = app.test_client()
+    resp = client.get("/user/check-token", query_string={"userId": "1"})
+    assert resp.status_code == 401
+    assert removed["uid"] == "1"


### PR DESCRIPTION
## Summary
- configure pytest with import root
- add unit tests for ResyClient and routes
- run tests for backend and frontend in GitHub Actions
- fix blueprint lookup helper in tests

## Testing
- `pytest -q` *(fails: command not found)*
- `pip install pytest` *(fails: no route to host)*