### PR TITLE
Add Resy client tests and update CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   backend:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -19,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r backend/requirements.txt
           pip install pytest
       - name: Run tests
         run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 pythonpath = backend
+testpaths = tests
+addopts = -ra -q

--- a/tests/test_resy_client.py
+++ b/tests/test_resy_client.py
@@ -1,6 +1,31 @@
+import logging
 import pytest
 from sortedcontainers import SortedList
-from app.core.resy_client import build_priority_list
+from app.core.resy_client import ResyClient, build_priority_list
+
+
+class DummyResp:
+    def __init__(self, status, data=None):
+        self.status_code = status
+        self._data = data or {}
+
+    def json(self):
+        return self._data
+
+
+class DummyAPI:
+    def __init__(self, responses=None):
+        self.responses = responses or {}
+        self.token = None
+
+    def set_resy_token(self, token):
+        self.token = token
+
+    def get_venue_details(self, venue_id):
+        return self.responses.get('venue_details', DummyResp(404))
+
+    def find_venue(self, query):
+        return self.responses.get('find_venue', DummyResp(404))
 
 
 def test_build_priority_list_selects_preceding_slots():
@@ -30,3 +55,55 @@ def test_build_priority_list_exact_match():
     res_times = ["2023-03-04 18:30"]
     result = build_priority_list(slots, res_times)
     assert result == [("2023-03-04 18:30", "t2")]
+
+
+def test_get_venue_details_success():
+    data = {
+        "id": {"resy": "1"},
+        "name": "Place",
+        "links": {"web": "http://example.com"},
+        "location": {"neighborhood": "Hood", "latitude": 1.0, "longitude": 2.0},
+    }
+    api = DummyAPI({"venue_details": DummyResp(200, data)})
+    client = ResyClient(api, logging.getLogger("test"))
+    details = client.get_venue_details("1")
+    assert details == {
+        "id": "1",
+        "name": "Place",
+        "website": "http://example.com",
+        "neighborhood": "Hood",
+        "lat": 1.0,
+        "lon": 2.0,
+    }
+
+
+def test_get_venue_details_failure():
+    api = DummyAPI({"venue_details": DummyResp(500)})
+    client = ResyClient(api, logging.getLogger("test"))
+    assert client.get_venue_details("1") is None
+
+
+def test_find_venue_sets_primary():
+    json_data = {
+        "results": {
+            "venues": [
+                {
+                    "venue": {
+                        "location": {
+                            "geo": {"lat": 1.234, "lon": 2.345},
+                            "neighborhood": "N",
+                        },
+                        "name": "Test",
+                        "id": {"resy": "42"},
+                    },
+                }
+            ]
+        }
+    }
+    api = DummyAPI({"find_venue": DummyResp(200, json_data)})
+    client = ResyClient(api, logging.getLogger("test"))
+    query = {"lat": 1.234, "long": 2.345}
+    result = client.find_venue("uid", query)
+    assert result["primary"] == {"id": "42", "name": "Test", "neighborhood": "N"}
+    assert result["search"][0]["lat"] == 1.234
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -106,3 +106,10 @@ def test_check_token_failure(fake_app):
     resp = client.get("/user/check-token", query_string={"userId": "1"})
     assert resp.status_code == 401
     assert removed["uid"] == "1"
+
+def test_venue_details_requires_auth(fake_app):
+    app = create_app("app.routes.resy_interactions")
+    client = app.test_client()
+    resp = client.get("/resy/venue-details")
+    assert resp.status_code == 403
+


### PR DESCRIPTION
## Summary
- configure pytest with a test path and terse output
- add unit tests for `ResyClient` and route handlers
- run backend tests from repo root in CI

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*